### PR TITLE
Fix duplicate polling

### DIFF
--- a/src/components/Session/index.jsx
+++ b/src/components/Session/index.jsx
@@ -11,7 +11,7 @@ import Search from './Search'
 import styles from './session.module.scss'
 
 const Session = () => {
-    const { queue, current } = useContext(SpotishareContext)
+    const { current } = useContext(SpotishareContext)
     const [searchOpen, setSearchOpen] = useState(false)
 
     const onOpen = () => setSearchOpen(true)
@@ -35,7 +35,7 @@ const Session = () => {
                                 progress={current.progress / current.song.duration_ms}
                                 className={styles.progress}
                             />
-                            <Queue queue={queue} className={styles.queue} />
+                            <Queue queue={current.queue} className={styles.queue} />
                         </React.Fragment>
                     )}
                 </Container>

--- a/src/components/SpotishareApp/index.jsx
+++ b/src/components/SpotishareApp/index.jsx
@@ -16,7 +16,7 @@ const SpotishareApp = () => {
 
     const [loading, setLoading] = useState(false)
     const [user, setUser] = useState(null)
-    const [session, setSession] = useState(null)
+    const [session, setSession] = useState({})
     const [current, setCurrent] = useState(null)
     const [queue, setQueue] = useState([])
 
@@ -55,7 +55,7 @@ const SpotishareApp = () => {
     }, [])
 
     useEffect(() => {
-        if (session) {
+        if (session.hash) {
             initCalls()
         }
     }, [session])

--- a/src/components/SpotishareApp/index.jsx
+++ b/src/components/SpotishareApp/index.jsx
@@ -7,7 +7,7 @@ import FrontPage from '../FrontPage'
 import { createSession, getMe, getSession } from '../../services/sessionApi'
 import Login from '../Login'
 import SpotishareContext from '../../spotishareContext'
-import { getCurrentSong, getSongList } from '../../services/songApi'
+import { getCurrent } from '../../services/songApi'
 
 const ONE_SECOND = 1000
 
@@ -16,17 +16,14 @@ const SpotishareApp = () => {
 
     const [loading, setLoading] = useState(false)
     const [user, setUser] = useState(null)
-    const [session, setSession] = useState({})
+    const [session, setSession] = useState(null)
     const [current, setCurrent] = useState(null)
-    const [queue, setQueue] = useState([])
 
     const initCalls = () => {
         clearInterval(interval)
         const call = () => {
-            getCurrentSong(session.hash)
+            getCurrent(session.hash)
                 .then(setCurrent)
-            getSongList(session.hash)
-                .then(setQueue)
         }
         interval = setInterval(call, ONE_SECOND)
         call()
@@ -55,7 +52,7 @@ const SpotishareApp = () => {
     }, [])
 
     useEffect(() => {
-        if (session.hash) {
+        if (session && session.hash) {
             initCalls()
         }
     }, [session])
@@ -72,7 +69,7 @@ const SpotishareApp = () => {
     ) : !user ? (
         <Login />
     ) : (
-        <SpotishareContext.Provider value={{ session, current, queue }}>
+        <SpotishareContext.Provider value={{ session, current }}>
             <Switch>
                 <Route path="/(session|s)/:id" component={Session} />
                 <Route path="/" component={() => <FrontPage onNewSession={onNewSession} />} />

--- a/src/services/songApi.js
+++ b/src/services/songApi.js
@@ -17,14 +17,7 @@ export const searchSong = (searchQuery, session) => {
     .then((response) => response.data.body && response.data.body.tracks && response.data.body.tracks.items || [])
 }
 
-export const getSongList = (session) => axios.get(`${apiUrl}/song`, {
-    params: {
-        session
-    }
-})
-    .then(({ data }) => data)
-
-export const getCurrentSong = (session) => axios.get(`${apiUrl}/song/current`, {
+export const getCurrent = (session) => axios.get(`${apiUrl}/song`, {
     params: {
         session
     }


### PR DESCRIPTION
Depends https://github.com/OREOA/spotishare-back/pull/8

Combined `GET '/song/current'` and `GET '/song'` into single request. The naming here sucks and the api should probably be refactored so that it would actually make some sense.

Also note that empty object is apparently truthy, which caused the polling to start with undefined `session.hash`. This wasn't cleared either when a hash was finally defined, so there might be something wrong with the the interval or effect hook.